### PR TITLE
Add support for Content Security Policy in Jenkins 2.539+

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 17], // use 'docker' if you have containerized tests
-    [platform: 'windows', jdk: 11],
+    [platform: 'linux', jdk: 25],
+    [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.31</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -30,21 +30,17 @@
         <changelist>999999-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.361.4</jenkins.version>
-        <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
+        <jenkins.version>2.539</jenkins.version>
+        <ban-junit4-imports.skip>true</ban-junit4-imports.skip>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>2025.v816d28f1e04f</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-suppressions</artifactId>
+            <version>${access-modifier-checker.version}</version>
+        </dependency>
+    </dependencies>
 
     <repositories>
         <repository>

--- a/src/main/java/io/jenkins/plugins/matomoanalytics/MatomoContributor.java
+++ b/src/main/java/io/jenkins/plugins/matomoanalytics/MatomoContributor.java
@@ -1,0 +1,31 @@
+package io.jenkins.plugins.matomoanalytics;
+
+import hudson.Extension;
+import hudson.ExtensionList;
+import jenkins.security.csp.Contributor;
+import jenkins.security.csp.CspBuilder;
+import jenkins.security.csp.Directive;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
+
+@Extension
+@SuppressRestrictedWarnings({Contributor.class, CspBuilder.class})
+public class MatomoContributor implements Contributor {
+    @Override
+    public void apply(CspBuilder cspBuilder) {
+        MatomoPageDecorator decorator = ExtensionList.lookupSingleton(MatomoPageDecorator.class);
+        String server = decorator.getMatomoServer();
+        String siteId = decorator.getMatomoSiteID();
+        if (server != null && siteId != null) {
+            String matomoJs = decorator.getMatomoJs();
+            if (matomoJs == null) {
+                matomoJs = "matomo.js";
+            }
+            String path = decorator.getMatomoPath();
+            if (path == null) {
+                path = "";
+            }
+            String scriptUrl = decorator.getProtocolString() + server + path + matomoJs;
+            cspBuilder.add(Directive.SCRIPT_SRC, scriptUrl);
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/jenkinsci/matomo-analytics-plugin/issues/7.

There's some duplication with existing code in the JS file, which could probably be done nicer by moving that into the `Decorator` class.

Additionally, some POM cleanup/enhancements:

* Updated the parent POM to a recent version
  * Removed the ban added in https://github.com/jenkinsci/matomo-analytics-plugin/pull/6 since it didn't actually have an effect with the ancient parent POM, and migrating tests would be out of scope for this PR.
* Removed `dependencyManagement` as it is unused anyway.
* Added dependency on `access-modifier-annotations` to be able to suppress warnings for the beta APIs allowing CSP contributions, without skipping `access-modifier` checks altogether.

### Testing done

I used `example.org/` and random other values for testing and confirmed this change contributes to the HTTP header, and no more warnings about browser rejecting to load the JS are shown.

**IMPORTANT**: If the Matomo JS file includes additional JS sources, this change will not be enough. I strongly recommend testing this interactively (Jenkins 2.539+ enforces CSP in `mvn hpi:run` which should make it easy given a real Matomo URL and ID etc.).

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
